### PR TITLE
FB authentication path changed from /oauth/authorize to /dialog/oauth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,63 @@
+PATH
+  remote: .
+  specs:
+    rest-more (2.0.0)
+      rest-core (>= 2.0.0)
+
+PATH
+  remote: rest-core
+  specs:
+    rest-core (2.0.2)
+      rest-client
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.3.2)
+    bacon (1.2.0)
+    cookiejar (0.3.0)
+    crack (0.3.2)
+    em-http-request (1.0.3)
+      addressable (>= 2.2.3)
+      cookiejar
+      em-socksify
+      eventmachine (>= 1.0.0.beta.4)
+      http_parser.rb (>= 0.5.3)
+    em-socksify (0.2.1)
+      eventmachine (>= 1.0.0.beta.4)
+    eventmachine (1.0.0)
+    http_parser.rb (0.5.3)
+    json (1.7.6)
+    json_pure (1.7.6)
+    mime-types (1.20.1)
+    multi_json (1.5.0)
+    rack (1.5.1)
+    rake (10.0.3)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    rr (1.0.4)
+    ruby-hmac (0.4.0)
+    webmock (1.9.0)
+      addressable (>= 2.2.7)
+      crack (>= 0.1.7)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bacon
+  em-http-request
+  jruby-openssl
+  json
+  json_pure
+  multi_json
+  rack
+  rake
+  rest-client
+  rest-core!
+  rest-more!
+  rr
+  ruby-hmac
+  webmock
+  yajl-ruby

--- a/example/rails3/Gemfile.lock
+++ b/example/rails3/Gemfile.lock
@@ -1,0 +1,116 @@
+PATH
+  remote: ../../
+  specs:
+    rest-more (2.0.0)
+      rest-core (>= 2.0.0)
+
+PATH
+  remote: ../../rest-core
+  specs:
+    rest-core (2.0.2)
+      rest-client
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    actionmailer (3.2.10)
+      actionpack (= 3.2.10)
+      mail (~> 2.4.4)
+    actionpack (3.2.10)
+      activemodel (= 3.2.10)
+      activesupport (= 3.2.10)
+      builder (~> 3.0.0)
+      erubis (~> 2.7.0)
+      journey (~> 1.0.4)
+      rack (~> 1.4.0)
+      rack-cache (~> 1.2)
+      rack-test (~> 0.6.1)
+      sprockets (~> 2.2.1)
+    activemodel (3.2.10)
+      activesupport (= 3.2.10)
+      builder (~> 3.0.0)
+    activerecord (3.2.10)
+      activemodel (= 3.2.10)
+      activesupport (= 3.2.10)
+      arel (~> 3.0.2)
+      tzinfo (~> 0.3.29)
+    activeresource (3.2.10)
+      activemodel (= 3.2.10)
+      activesupport (= 3.2.10)
+    activesupport (3.2.10)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
+    addressable (2.3.2)
+    arel (3.0.2)
+    builder (3.0.4)
+    crack (0.3.2)
+    erubis (2.7.0)
+    hike (1.2.1)
+    i18n (0.6.1)
+    journey (1.0.4)
+    json (1.7.6)
+    mail (2.4.4)
+      i18n (>= 0.4.0)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mime-types (1.20.1)
+    multi_json (1.5.0)
+    polyglot (0.3.3)
+    psych (1.3.4)
+    rack (1.4.4)
+    rack-cache (1.2)
+      rack (>= 0.4)
+    rack-ssl (1.3.3)
+      rack
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    rails (3.2.10)
+      actionmailer (= 3.2.10)
+      actionpack (= 3.2.10)
+      activerecord (= 3.2.10)
+      activeresource (= 3.2.10)
+      activesupport (= 3.2.10)
+      bundler (~> 1.0)
+      railties (= 3.2.10)
+    railties (3.2.10)
+      actionpack (= 3.2.10)
+      activesupport (= 3.2.10)
+      rack-ssl (~> 1.3.2)
+      rake (>= 0.8.7)
+      rdoc (~> 3.4)
+      thor (>= 0.14.6, < 2.0)
+    rake (10.0.3)
+    rdoc (3.12.1)
+      json (~> 1.4)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    rr (1.0.4)
+    sprockets (2.2.2)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+    thor (0.17.0)
+    tilt (1.3.3)
+    treetop (1.4.12)
+      polyglot
+      polyglot (>= 0.3.1)
+    tzinfo (0.3.35)
+    webmock (1.9.0)
+      addressable (>= 2.2.7)
+      crack (>= 0.1.7)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jruby-openssl
+  psych
+  rails (= 3.2.10)
+  rest-client
+  rest-core!
+  rest-more!
+  rr
+  webmock
+  yajl-ruby

--- a/example/rails3/test/functional/application_controller_test.rb
+++ b/example/rails3/test/functional/application_controller_test.rb
@@ -47,7 +47,7 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_response :redirect
 
     url = normalize_url(
-      'https://graph.facebook.com/oauth/authorize?client_id=123&' \
+      'https://graph.facebook.com/dialog/oauth?client_id=123&' \
       'scope=&redirect_uri=http%3A%2F%2Ftest.host%2F')
 
     assert_url(url)
@@ -58,7 +58,7 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_response :success
 
     url = normalize_url(
-      'https://graph.facebook.com/oauth/authorize?client_id=123&' \
+      'https://graph.facebook.com/dialog/oauth?client_id=123&' \
       'scope=publish_stream&'                                     \
       'redirect_uri=http%3A%2F%2Fapps.facebook.com%2Fcan%2Fcanvas')
 
@@ -70,7 +70,7 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_response :success
 
     url = normalize_url(
-      'https://graph.facebook.com/oauth/authorize?client_id=123&' \
+      'https://graph.facebook.com/dialog/oauth?client_id=123&' \
       'scope=email&'                                              \
       'redirect_uri=http%3A%2F%2Fapps.facebook.com%2FToT%2Fdiff_canvas')
 
@@ -82,7 +82,7 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_response :success
 
     url = normalize_url(
-      'https://graph.facebook.com/oauth/authorize?client_id=123&' \
+      'https://graph.facebook.com/dialog/oauth?client_id=123&' \
       'scope=&'                                                   \
       'redirect_uri=http%3A%2F%2Fapps.facebook.com%2Fzzz%2Fiframe_canvas')
 
@@ -94,7 +94,7 @@ class ApplicationControllerTest < ActionController::TestCase
     assert_response :redirect
 
     url = normalize_url(
-      'https://graph.facebook.com/oauth/authorize?client_id=123&' \
+      'https://graph.facebook.com/dialog/oauth?client_id=123&' \
       'scope=bogus&'                                              \
       'redirect_uri=http%3A%2F%2Ftest.host%2Foptions')
 

--- a/lib/rest-core/client/facebook.rb
+++ b/lib/rest-core/client/facebook.rb
@@ -211,7 +211,7 @@ module RestCore::Facebook::Client
   # oauth related
 
   def authorize_url opts={}
-    url('oauth/authorize',
+    url('dialog/oauth',
         {:client_id => app_id, :access_token => nil}.merge(opts))
   end
 

--- a/test/facebook/test_oauth.rb
+++ b/test/facebook/test_oauth.rb
@@ -13,7 +13,7 @@ describe RC::Facebook do
 
   should 'return correct oauth url' do
     TestHelper.normalize_url(@rg.authorize_url(:redirect_uri => @uri)).
-    should.eq 'https://graph.facebook.com/oauth/authorize?' \
+    should.eq 'https://graph.facebook.com/dialog/oauth?' \
               'client_id=29&redirect_uri=http%3A%2F%2Fzzz.tw'
   end
 
@@ -34,7 +34,7 @@ describe RC::Facebook do
 
   should 'not append access_token in authorize_url even presented' do
     RC::Facebook.new(:access_token => 'do not use me').authorize_url.
-      should.eq 'https://graph.facebook.com/oauth/authorize'
+      should.eq 'https://graph.facebook.com/dialog/oauth'
   end
 
 end


### PR DESCRIPTION
We might want to update our paths, since yesterday accidentally made breaking changes.
https://developers.facebook.com/bugs/207955409343730

https://developers.facebook.com/docs/howtos/login/server-side-login/
